### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+++ b/dev/eks/skylab/infra/crossplane/catalog-info.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: skylab-eks-cluster
+  title: Skylab EKS Cluster (Crossplane)
+  description: Standard EKS cluster for dev environment managed by Crossplane
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/techdocs-ref: dir:./infra/crossplane
+    argocd/app-name: skylab-crossplane-infra-dev
+    crossplane.io/composite-resource: skylab-eks-cluster
+  tags:
+    - kubernetes
+    - eks
+    - crossplane
+    - infrastructure
+    - dev
+    - eks
+    - standard
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    layer: infra
+    component: crossplane
+  links:
+    - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab
+      title: AWS EKS Console
+      icon: cloud
+    - url: https://argocd.skylab.com/applications?search=skylab
+      title: ArgoCD Applications
+      icon: dashboard
+    - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev/eks/skylab/infra/crossplane
+      title: Source Code
+      icon: github
+spec:
+  type: kubernetes-cluster
+  lifecycle: dev
+  owner: platform-team
+  system: infrastructure
+  dependsOn: []
+  providesApis: []
+  consumesApis: []

--- a/dev/eks/skylab/infra/crossplane/docs/architecture.md
+++ b/dev/eks/skylab/infra/crossplane/docs/architecture.md
@@ -1,0 +1,29 @@
+# Architecture
+
+## Infrastructure Components
+
+### Networking
+- **VPC**: `skylab-vpc` (192.168.0.0/16)
+- **Subnets**: 
+  - `skylab-us-east-2a` (192.168.10.0/24)
+  - `skylab-us-east-2c` (192.168.11.0/24)
+- **Internet Gateway**: `skylab-igw`
+- **Route Table**: `skylab-public-rt`
+
+### Security
+- **Security Group**: `skylab-sg`
+- **Cluster Role**: `skylab-cluster-role`
+- **Node Role**: `skylab-node-role`
+
+### Compute
+- **EKS Cluster**: `skylab` (Kubernetes 1.28)
+- **Node Group**: `skylab-nodegroup`
+
+## Crossplane Resources
+
+This cluster is defined as a Crossplane Composition that creates and manages all AWS resources automatically.
+
+### Connection Secret
+Cluster credentials are stored in:
+- **Namespace**: `crossplane-system`
+- **Secret**: `skylab-conn`

--- a/dev/eks/skylab/infra/crossplane/docs/index.md
+++ b/dev/eks/skylab/infra/crossplane/docs/index.md
@@ -1,0 +1,24 @@
+# Skylab EKS Cluster
+
+## Overview
+
+This EKS cluster is managed by Crossplane and deployed via ArgoCD in the **dev** environment.
+
+## Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Cluster Name | skylab |
+| Environment | dev |
+| Platform | eks |
+| Variant | standard |
+| Region | us-east-2 |
+| Node Count | 1 |
+| Node Size | t3.medium |
+
+## Quick Links
+
+- [AWS Console](https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab)
+- [ArgoCD Applications](https://argocd.skylab.com/applications?search=skylab)
+- [Architecture Details](architecture.md)
+- [Operations Guide](operations.md)

--- a/dev/eks/skylab/infra/crossplane/docs/operations.md
+++ b/dev/eks/skylab/infra/crossplane/docs/operations.md
@@ -1,0 +1,42 @@
+
+# Operations Guide
+
+## ArgoCD Integration
+
+**Application Name**: `{cluster-name}-crossplane-infra-dev`
+
+## Monitoring
+
+### Health Checks
+```bash
+# Check ArgoCD application
+kubectl get applications -n argocd | grep skylab
+
+# Check Crossplane resources
+kubectl get composite -A
+kubectl get managed -A | grep skylab
+```
+
+### Accessing the Cluster
+```bash
+# Get connection secret
+kubectl get secret skylab-conn -n crossplane-system -o yaml
+
+# Update kubeconfig (after extracting from secret)
+aws eks update-kubeconfig --region us-east-2 --name skylab
+```
+
+## Scaling
+
+### Node Group Scaling
+The node group can be scaled by updating the Crossplane composition:
+- **Current Size**: 1
+- **Min Size**: 1
+- **Max Size**: 1
+
+## Backup & Recovery
+
+### Cluster State
+- Infrastructure is code-managed via Crossplane
+- Application state should be backed up separately
+- EKS control plane is managed by AWS

--- a/dev/eks/skylab/infra/crossplane/docs/troubleshooting.md
+++ b/dev/eks/skylab/infra/crossplane/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+## Common Issues
+
+### Cluster Not Appearing
+1. Check ArgoCD sync status
+2. Verify ApplicationSet is running
+3. Check cluster labels match ApplicationSet selectors
+
+### Resources Stuck in Provisioning
+1. Check Crossplane provider logs:
+   ```bash
+   kubectl logs -n crossplane-system deployment/crossplane-provider-aws
+   ```
+2. Verify AWS credentials and permissions
+3. Check resource events in AWS console
+
+### Access Denied
+1. Verify IAM roles are properly attached
+2. Check security group rules
+3. Confirm VPC and subnet configuration
+
+## Useful Commands
+
+```bash
+# Check all Crossplane resources for this cluster
+kubectl get managed -A -l cluster-name=skylab
+
+# View Crossplane events
+kubectl get events -n crossplane-system
+
+# Check provider configuration
+kubectl get providerconfigs
+
+# View composition status
+kubectl describe composition skylab-eks-cluster
+```
+
+## Support Contacts
+
+- **Platform Team**: platform-team@skylab.com
+- **On-call**: See PagerDuty rotation

--- a/dev/eks/skylab/infra/crossplane/kustomization.yaml
+++ b/dev/eks/skylab/infra/crossplane/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: skylab-crossplane-cluster
+
+resources:
+  - manifests/composition.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: crossplane
+    layer: infra
+    component: crossplane
+
+namespace: crossplane-system
+
+patches:
+  - target:
+      kind: Composition
+      name: skylab-eks-cluster
+    patch: |-
+      - op: add
+        path: /metadata/labels/backstage.io~1managed-by
+        value: template

--- a/dev/eks/skylab/infra/crossplane/manifests/composition.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/composition.yaml
@@ -1,0 +1,628 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: skylab-eks-cluster
+  labels:
+    provider: aws
+    cluster-type: eks
+    environment: dev
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: infrastructure.skylab.com/v1alpha1
+    kind: XEKSCluster
+  
+  resources:
+    # VPC
+    - name: vpc
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: VPC
+        metadata:
+          name: skylab-vpc
+        spec:
+          forProvider:
+            region: us-east-2
+            cidrBlock: 192.168.0.0/16
+            enableDnsHostNames: true
+            enableDnsSupport: true
+            instanceTenancy: default
+            tags:
+              - key: Name
+                value: skylab-vpc
+              - key: Environment
+                value: dev
+              - key: ClusterType
+                value: eks
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.environment
+          toFieldPath: spec.forProvider.tags[1].value
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterType
+          toFieldPath: spec.forProvider.tags[2].value
+
+    # Internet Gateway
+    - name: igw
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: InternetGateway
+        metadata:
+          name: skylab-igw
+        spec:
+          forProvider:
+            region: us-east-2
+            vpcIdRef:
+              name: skylab-vpc
+            tags:
+              - key: Name
+                value: skylab-igw
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-igw"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.vpcIdRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+
+    # Subnet 1 (us-east-2a)
+    - name: subnet-2a
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          name: skylab-us-east-2a
+        spec:
+          forProvider:
+            region: us-east-2
+            availabilityZone: us-east-2a
+            cidrBlock: 192.168.10.0/24
+            vpcIdRef:
+              name: skylab-vpc
+            mapPublicIpOnLaunch: true
+            tags:
+              - key: Name
+                value: skylab-us-east-2a
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.availabilityZone
+          transforms:
+            - type: string
+              string:
+                fmt: "%sa"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-us-east-2a"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.vpcIdRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+
+    # Subnet 2 (us-east-2c)
+    - name: subnet-2c
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Subnet
+        metadata:
+          name: skylab-us-east-2c
+        spec:
+          forProvider:
+            region: us-east-2
+            availabilityZone: us-east-2c
+            cidrBlock: 192.168.11.0/24
+            vpcIdRef:
+              name: skylab-vpc
+            mapPublicIpOnLaunch: true
+            tags:
+              - key: Name
+                value: skylab-us-east-2c
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.availabilityZone
+          transforms:
+            - type: string
+              string:
+                fmt: "%sc"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-us-east-2c"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.vpcIdRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+
+    # Route Table
+    - name: route-table
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: RouteTable
+        metadata:
+          name: skylab-public-rt
+        spec:
+          forProvider:
+            region: us-east-2
+            vpcIdRef:
+              name: skylab-vpc
+            associations:
+              - subnetIdRef:
+                  name: skylab-us-east-2a
+              - subnetIdRef:
+                  name: skylab-us-east-2c
+            routes:
+              - destinationCidrBlock: 0.0.0.0/0
+                gatewayIdRef:
+                  name: skylab-igw
+            tags:
+              - key: Name
+                value: skylab-public-rt
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-public-rt"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.vpcIdRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+
+    # Security Group
+    - name: security-group
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        metadata:
+          name: skylab-sg
+        spec:
+          forProvider:
+            groupName: skylab-sg
+            region: us-east-2
+            vpcIdRef:
+              name: skylab-vpc
+            description: "EKS cluster security group"
+            ingress:
+              - fromPort: -1
+                ipProtocol: "-1"
+                ipRanges:
+                  - cidrIp: 68.52.182.6/32
+                toPort: -1
+            egress:
+              - fromPort: -1
+                ipProtocol: "-1"
+                ipRanges:
+                  - cidrIp: 0.0.0.0/0
+                toPort: -1
+            tags:
+              - key: Name
+                value: skylab-sg
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-sg"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.groupName
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-sg"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.vpcIdRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-vpc"
+
+    # EKS Cluster IAM Role
+    - name: cluster-role
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
+        metadata:
+          name: skylab-cluster-role
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": "eks.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                  }
+                ]
+              }
+            tags:
+              - key: Name
+                value: skylab-cluster-role
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cluster-role"
+
+    # EKS Cluster IAM Role Policy Attachment
+    - name: cluster-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        metadata:
+          name: skylab-cluster-policy
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+            roleNameRef:
+              name: skylab-cluster-role
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cluster-policy"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.roleNameRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cluster-role"
+
+    # Node Group IAM Role
+    - name: node-role
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Role
+        metadata:
+          name: skylab-node-role
+        spec:
+          forProvider:
+            assumeRolePolicyDocument: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Service": "ec2.amazonaws.com"
+                    },
+                    "Action": "sts:AssumeRole"
+                  }
+                ]
+              }
+            tags:
+              - key: Name
+                value: skylab-node-role
+              - key: Environment
+                value: dev
+              - key: ManagedBy
+                value: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-node-role"
+
+    # Node Group IAM Role Policy Attachments
+    - name: worker-node-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        metadata:
+          name: skylab-worker-node-policy
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+            roleNameRef:
+              name: skylab-node-role
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-worker-node-policy"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.roleNameRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-node-role"
+
+    - name: cni-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        metadata:
+          name: skylab-cni-policy
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+            roleNameRef:
+              name: skylab-node-role
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-cni-policy"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.roleNameRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-node-role"
+
+    - name: ecr-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        metadata:
+          name: skylab-ecr-policy
+        spec:
+          forProvider:
+            policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+            roleNameRef:
+              name: skylab-node-role
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-ecr-policy"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.roleNameRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-node-role"
+
+    # EKS Cluster
+    - name: eks-cluster
+      base:
+        apiVersion: eks.aws.crossplane.io/v1beta1
+        kind: Cluster
+        metadata:
+          name: skylab
+        spec:
+          forProvider:
+            region: us-east-2
+            version: "1.28"
+            roleArnRef:
+              name: skylab-cluster-role
+            resourcesVpcConfig:
+              endpointPrivateAccess: false
+              endpointPublicAccess: true
+              securityGroupIdRefs:
+                - name: skylab-sg
+              subnetIdRefs:
+                - name: skylab-us-east-2a
+                - name: skylab-us-east-2c
+            tags:
+              Name: skylab
+              Environment: dev
+              ClusterType: eks
+              ManagedBy: crossplane
+          providerConfigRef:
+            name: default
+          writeConnectionSecretToRef:
+            name: skylab-conn
+            namespace: crossplane-system
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.kubernetesVersion
+          toFieldPath: spec.forProvider.version
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.environment
+          toFieldPath: spec.forProvider.tags.Environment
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterType
+          toFieldPath: spec.forProvider.tags.ClusterType
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.writeConnectionSecretToRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-conn"
+
+    # EKS Node Group
+    - name: nodegroup
+      base:
+        apiVersion: eks.aws.crossplane.io/v1alpha1
+        kind: NodeGroup
+        metadata:
+          name: skylab-nodegroup
+        spec:
+          forProvider:
+            region: us-east-2
+            clusterNameRef:
+              name: skylab
+            nodeRoleRef:
+              name: skylab-node-role
+            subnetRefs:
+              - name: skylab-us-east-2a
+              - name: skylab-us-east-2c
+            scalingConfig:
+              desiredSize: 1
+              maxSize: 1
+              minSize: 1
+            instanceTypes:
+              - t3.medium
+            tags:
+              Name: skylab-nodegroup
+              Environment: dev
+              ClusterType: eks
+              ManagedBy: crossplane
+          providerConfigRef:
+            name: default
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-nodegroup"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.clusterNameRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterName
+          toFieldPath: spec.forProvider.nodeRoleRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-node-role"
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.nodeCount
+          toFieldPath: spec.forProvider.scalingConfig.desiredSize
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.nodeCount
+          toFieldPath: spec.forProvider.scalingConfig.maxSize
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.nodeSize
+          toFieldPath: spec.forProvider.instanceTypes[0]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.environment
+          toFieldPath: spec.forProvider.tags.Environment
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.clusterType
+          toFieldPath: spec.forProvider.tags.ClusterType

--- a/dev/eks/skylab/infra/crossplane/techdocs.yaml
+++ b/dev/eks/skylab/infra/crossplane/techdocs.yaml
@@ -1,0 +1,18 @@
+---
+site_name: 'Skylab EKS Cluster'
+site_description: 'Documentation for skylab EKS cluster infrastructure'
+
+nav:
+  - Overview: index.md
+  - Architecture: architecture.md
+  - Operations: operations.md
+  - Troubleshooting: troubleshooting.md
+
+plugins:
+  - techdocs-core
+
+theme:
+  name: material
+  palette:
+    primary: green
+    accent: black


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1
- **Node Size**: t3.medium

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
