### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+++ b/dev/eks/skylab/infra/crossplane/catalog-info.yaml
@@ -28,7 +28,7 @@ metadata:
     - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab
       title: AWS EKS Console
       icon: cloud
-    - url: https://argocd.skylarhoughtongithub.local/applications?search=skylab
+    - url: https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev
       title: ArgoCD Applications
       icon: dashboard
     - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev/eks/skylab/infra/crossplane

--- a/dev/eks/skylab/infra/crossplane/docs/index.md
+++ b/dev/eks/skylab/infra/crossplane/docs/index.md
@@ -19,6 +19,6 @@ This EKS cluster is managed by Crossplane and deployed via ArgoCD in the **dev**
 ## Quick Links
 
 - [AWS Console](https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab)
-- [ArgoCD Applications](https://argocd.skylarhoughtongithub.local/applications?search=skylab)
+- [ArgoCD Applications](https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev)
 - [Architecture Details](architecture.md)
 - [Operations Guide](operations.md)


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1
- **Node Size**: t3.medium

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
