### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
@@ -35,4 +35,12 @@ spec:
   allowedCidrs:
     - "0.0.0.0/0"  # Dev is open for testing
 
-  # Readonly access entries - simpler conditional approach
+  debugValues:
+    adminAccessEntryName1: ""
+    adminAccessEntryType1: ""
+    adminAccessEntryName2: ""
+    adminAccessEntryType2: ""
+    readOnlyAccessEntryName1: ""
+    readOnlyAccessEntryType1: ""
+    readOnlyAccessEntryName2: ""
+    readOnlyAccessEntryType2: ""


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1
- **Node Size**: t3.medium

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
