### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
@@ -34,16 +34,6 @@ spec:
   # Security configuration - environment-specific access
   allowedCidrs:
     - "0.0.0.0/0"  # Dev is open for testing
-
-  debugValues:
-    adminAccessEntryName1: "chicken"
-    adminAccessEntryType1: "user"
-    adminAccessEntryName2: ""
-    adminAccessEntryType2: "role"
-    readOnlyAccessEntryName1: ""
-    readOnlyAccessEntryType1: "role"
-    readOnlyAccessEntryName2: ""
-    readOnlyAccessEntryType2: "role"
   adminPrincipals:
     - name: chicken
       type: user


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1
- **Node Size**: t3.medium

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
