### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+++ b/dev/eks/skylab/infra/crossplane/catalog-info.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: skylab-eks-cluster
+  title: Skylab EKS Cluster (Crossplane)
+  description: Standard EKS cluster for dev environment managed by Crossplane
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/techdocs-ref: dir:.
+    argocd/app-name: skylab-cluster-2-crossplane-infra-dev
+    crossplane.io/composite-resource: skylab-eks-cluster
+  tags:
+    - kubernetes
+    - eks
+    - crossplane
+    - infrastructure
+    - dev
+    - eks
+    - standard
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    layer: infra
+    component: crossplane
+  links:
+    - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab
+      title: AWS EKS Console
+      icon: cloud
+    - url: https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev
+      title: ArgoCD Applications
+      icon: dashboard
+    - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev/eks/skylab/infra/crossplane
+      title: Source Code
+      icon: github
+spec:
+  type: kubernetes-cluster
+  lifecycle: dev
+  owner: platform-team
+  system: infrastructure
+  dependsOn: []
+  providesApis: []
+  consumesApis: []

--- a/dev/eks/skylab/infra/crossplane/docs/architecture.md
+++ b/dev/eks/skylab/infra/crossplane/docs/architecture.md
@@ -1,0 +1,29 @@
+# Architecture
+
+## Infrastructure Components
+
+### Networking
+- **VPC**: `skylab-vpc` (192.168.0.0/16)
+- **Subnets**: 
+  - `skylab-us-east-2a` (192.168.10.0/24)
+  - `skylab-us-east-2c` (192.168.11.0/24)
+- **Internet Gateway**: `skylab-igw`
+- **Route Table**: `skylab-public-rt`
+
+### Security
+- **Security Group**: `skylab-sg`
+- **Cluster Role**: `skylab-cluster-role`
+- **Node Role**: `skylab-node-role`
+
+### Compute
+- **EKS Cluster**: `skylab` (Kubernetes 1.28)
+- **Node Group**: `skylab-nodegroup`
+
+## Crossplane Resources
+
+This cluster is defined as a Crossplane Composition that creates and manages all AWS resources automatically.
+
+### Connection Secret
+Cluster credentials are stored in:
+- **Namespace**: `crossplane-system`
+- **Secret**: `skylab-conn`

--- a/dev/eks/skylab/infra/crossplane/docs/index.md
+++ b/dev/eks/skylab/infra/crossplane/docs/index.md
@@ -1,0 +1,24 @@
+# Skylab EKS Cluster
+
+## Overview
+
+This EKS cluster is managed by Crossplane and deployed via ArgoCD in the **dev** environment.
+
+## Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Cluster Name | skylab |
+| Environment | dev |
+| Platform | eks |
+| Variant | standard |
+| Region | us-east-2 |
+| Node Count | 1 |
+| Node Size | t3.medium |
+
+## Quick Links
+
+- [AWS Console](https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab)
+- [ArgoCD Applications](https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev)
+- [Architecture Details](architecture.md)
+- [Operations Guide](operations.md)

--- a/dev/eks/skylab/infra/crossplane/docs/operations.md
+++ b/dev/eks/skylab/infra/crossplane/docs/operations.md
@@ -1,0 +1,42 @@
+
+# Operations Guide
+
+## ArgoCD Integration
+
+**Application Name**: `{cluster-name}-crossplane-infra-dev`
+
+## Monitoring
+
+### Health Checks
+```bash
+# Check ArgoCD application
+kubectl get applications -n argocd | grep skylab
+
+# Check Crossplane resources
+kubectl get composite -A
+kubectl get managed -A | grep skylab
+```
+
+### Accessing the Cluster
+```bash
+# Get connection secret
+kubectl get secret skylab-conn -n crossplane-system -o yaml
+
+# Update kubeconfig (after extracting from secret)
+aws eks update-kubeconfig --region us-east-2 --name skylab
+```
+
+## Scaling
+
+### Node Group Scaling
+The node group can be scaled by updating the Crossplane composition:
+- **Current Size**: 1
+- **Min Size**: 1
+- **Max Size**: 1
+
+## Backup & Recovery
+
+### Cluster State
+- Infrastructure is code-managed via Crossplane
+- Application state should be backed up separately
+- EKS control plane is managed by AWS

--- a/dev/eks/skylab/infra/crossplane/docs/troubleshooting.md
+++ b/dev/eks/skylab/infra/crossplane/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+## Common Issues
+
+### Cluster Not Appearing
+1. Check ArgoCD sync status
+2. Verify ApplicationSet is running
+3. Check cluster labels match ApplicationSet selectors
+
+### Resources Stuck in Provisioning
+1. Check Crossplane provider logs:
+   ```bash
+   kubectl logs -n crossplane-system deployment/crossplane-provider-aws
+   ```
+2. Verify AWS credentials and permissions
+3. Check resource events in AWS console
+
+### Access Denied
+1. Verify IAM roles are properly attached
+2. Check security group rules
+3. Confirm VPC and subnet configuration
+
+## Useful Commands
+
+```bash
+# Check all Crossplane resources for this cluster
+kubectl get managed -A -l cluster-name=skylab
+
+# View Crossplane events
+kubectl get events -n crossplane-system
+
+# Check provider configuration
+kubectl get providerconfigs
+
+# View composition status
+kubectl describe composition skylab-eks-cluster
+```
+
+## Support Contacts
+
+- **Platform Team**: platform-team@skylab.com
+- **On-call**: See PagerDuty rotation

--- a/dev/eks/skylab/infra/crossplane/kustomization.yaml
+++ b/dev/eks/skylab/infra/crossplane/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: skylab-crossplane-cluster
+
+resources:
+  - manifests/xeksclusters.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: crossplane
+    layer: infra
+    component: crossplane
+
+namespace: crossplane-system
+
+patches:
+  - target:
+      kind: Composition
+      name: skylab-eks-cluster
+    patch: |-
+      - op: add
+        path: /metadata/labels/backstage.io~1managed-by
+        value: template

--- a/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xeksclusters.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: infrastructure.skylab.com/v1alpha1
+kind: XEKSCluster
+metadata:
+  name: skylab-cluster
+  namespace: crossplane-skylab
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: backstage-template
+    template: eks-cluster-crossplane
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    template.backstage.io/created-by: skylab-eks-cluster-template
+spec:
+  # Core cluster configuration
+  clusterName: skylab-dev
+  region: us-east-2
+  environment: dev
+  clusterType: standard
+  kubernetesVersion: "1.33"
+  
+  # Node configuration
+  nodeCount: 1
+  nodeSize: t3.medium
+  
+  # Network configuration - environment-based CIDR allocation
+  vpcCidr: "10.10.0.0/16"
+  subnetCidrs:
+    - "10.10.1.0/24"
+    - "10.10.2.0/24"
+  
+  # Security configuration - environment-specific access
+  allowedCidrs:
+    - "0.0.0.0/0"  # Dev is open for testing
+  adminPrincipals:
+    - name: chicken
+      type: user

--- a/dev/eks/skylab/infra/crossplane/techdocs.yaml
+++ b/dev/eks/skylab/infra/crossplane/techdocs.yaml
@@ -1,0 +1,18 @@
+---
+site_name: 'Skylab EKS Cluster'
+site_description: 'Documentation for skylab EKS cluster infrastructure'
+
+nav:
+  - Overview: index.md
+  - Architecture: architecture.md
+  - Operations: operations.md
+  - Troubleshooting: troubleshooting.md
+
+plugins:
+  - techdocs-core
+
+theme:
+  name: material
+  palette:
+    primary: green
+    accent: black


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1
- **Node Size**: t3.medium

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
