### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/manifests/xclusterrbac.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xclusterrbac.yaml
@@ -19,4 +19,3 @@ metadata:
 spec:
   clusterName: skylab-dev
   environment: dev
-  includeEbsCsiPolicy: true


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1 (min: 1, max: 3)
- **Node Size**: t3.medium
- **Capacity Type**: ON_DEMAND

### Access Configuration
- **Admin Access**: chicken (user)

### Components Created
- Network composition (VPC, subnets, security groups)
- RBAC composition (IAM roles and policies)
- EKS cluster composition (cluster, node group, add-ons)
- Access entries composition (IAM access entries)

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
