### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/manifests/xekscluster.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xekscluster.yaml
@@ -42,12 +42,3 @@ spec:
     capacityType: ON_DEMAND
     amiType: AL2_x86_64
     diskSize: 20
-  
-  # EKS Add-ons
-  addons:
-    vpcCni:
-      version: ""
-    coreDns:
-      version: ""
-    kubeProxy:
-      version: ""


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1 (min: 1, max: 3)
- **Node Size**: t3.medium
- **Capacity Type**: ON_DEMAND

### Access Configuration
- **Admin Access**: chicken (user)

### Components Created
- Network composition (VPC, subnets, security groups)
- RBAC composition (IAM roles and policies)
- EKS cluster composition (cluster, node group, add-ons)
- Access entries composition (IAM access entries)

This PR adds new cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
