### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+++ b/dev/eks/skylab/infra/crossplane/catalog-info.yaml
@@ -3,10 +3,10 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: skylab-eks-cluster
-  title: Skylab EKS Cluster (Crossplane)
+  title: Skylab EKS Cluster
   description: Standard EKS cluster for dev environment managed by Crossplane
   annotations:
-    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev///skylab/infra/crossplane/catalog-info.yaml
     backstage.io/techdocs-ref: dir:.
     argocd/app-name: skylab-cluster-2-crossplane-infra-dev
     crossplane.io/composite-resource: skylab-eks-cluster
@@ -25,13 +25,13 @@ metadata:
     layer: infra
     component: crossplane
   links:
-    - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab
+    - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab-dev
       title: AWS EKS Console
       icon: cloud
     - url: https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev
       title: ArgoCD Applications
       icon: dashboard
-    - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev/eks/skylab/infra/crossplane
+    - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev///skylab/infra/crossplane
       title: Source Code
       icon: github
 spec:

--- a/dev/eks/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
+++ b/dev/eks/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
@@ -22,5 +22,3 @@ spec:
   adminPrincipal:
     name: chicken
     type: user
-
-# ReadOnly Access Entry Composition (Optional)


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1 (min: 1, max: 3)
- **Node Size**: t3.medium
- **Capacity Type**: ON_DEMAND

### Access Configuration
- **Admin Access**: chicken (user) - AmazonEKSClusterAdminPolicy

### Components Created
- **Network composition** (VPC, subnets, security groups, routing)
- **RBAC composition** (IAM roles and policies for EKS)
- **EKS cluster composition** (cluster, node group, add-ons)
- **Admin access composition** (admin access entry + policy association)

This PR adds new modular cluster infrastructure to `dev/eks/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
