### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: skylab-eks-cluster
+  title: Skylab EKS Cluster
+  description: Standard EKS cluster for dev environment managed by Crossplane
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/techdocs-ref: dir:.
+    argocd/app-name: skylab-cluster-2-crossplane-infra-dev
+    crossplane.io/composite-resource: skylab-eks-cluster
+  tags:
+    - kubernetes
+    - eks
+    - crossplane
+    - infrastructure
+    - dev
+    - eks
+    - standard
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    layer: infra
+    component: crossplane
+  links:
+    - url: https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab-dev
+      title: AWS EKS Console
+      icon: cloud
+    - url: https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev
+      title: ArgoCD Applications
+      icon: dashboard
+    - url: https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/tree/main/dev/eks/standard/skylab/infra/crossplane
+      title: Source Code
+      icon: github
+spec:
+  type: kubernetes-cluster
+  lifecycle: dev
+  owner: platform-team
+  system: infrastructure
+  dependsOn: []
+  providesApis: []
+  consumesApis: []

--- a/dev/eks/standard/skylab/infra/crossplane/docs/architecture.md
+++ b/dev/eks/standard/skylab/infra/crossplane/docs/architecture.md
@@ -1,0 +1,29 @@
+# Architecture
+
+## Infrastructure Components
+
+### Networking
+- **VPC**: `skylab-vpc` (192.168.0.0/16)
+- **Subnets**: 
+  - `skylab-us-east-2a` (192.168.10.0/24)
+  - `skylab-us-east-2c` (192.168.11.0/24)
+- **Internet Gateway**: `skylab-igw`
+- **Route Table**: `skylab-public-rt`
+
+### Security
+- **Security Group**: `skylab-sg`
+- **Cluster Role**: `skylab-cluster-role`
+- **Node Role**: `skylab-node-role`
+
+### Compute
+- **EKS Cluster**: `skylab` (Kubernetes 1.28)
+- **Node Group**: `skylab-nodegroup`
+
+## Crossplane Resources
+
+This cluster is defined as a Crossplane Composition that creates and manages all AWS resources automatically.
+
+### Connection Secret
+Cluster credentials are stored in:
+- **Namespace**: `crossplane-system`
+- **Secret**: `skylab-conn`

--- a/dev/eks/standard/skylab/infra/crossplane/docs/index.md
+++ b/dev/eks/standard/skylab/infra/crossplane/docs/index.md
@@ -1,0 +1,24 @@
+# Skylab EKS Cluster
+
+## Overview
+
+This EKS cluster is managed by Crossplane and deployed via ArgoCD in the **dev** environment.
+
+## Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Cluster Name | skylab |
+| Environment | dev |
+| Platform | eks |
+| Variant | standard |
+| Region | us-east-2 |
+| Node Count | 1 |
+| Node Size | t3.medium |
+
+## Quick Links
+
+- [AWS Console](https://console.aws.amazon.com/eks/home?region=us-east-2#/clusters/skylab)
+- [ArgoCD Applications](https://argocd.skylarhoughtongithub.local/applications?search=skylab-crossplane-infra-dev)
+- [Architecture Details](architecture.md)
+- [Operations Guide](operations.md)

--- a/dev/eks/standard/skylab/infra/crossplane/docs/operations.md
+++ b/dev/eks/standard/skylab/infra/crossplane/docs/operations.md
@@ -1,0 +1,42 @@
+
+# Operations Guide
+
+## ArgoCD Integration
+
+**Application Name**: `{cluster-name}-crossplane-infra-dev`
+
+## Monitoring
+
+### Health Checks
+```bash
+# Check ArgoCD application
+kubectl get applications -n argocd | grep skylab
+
+# Check Crossplane resources
+kubectl get composite -A
+kubectl get managed -A | grep skylab
+```
+
+### Accessing the Cluster
+```bash
+# Get connection secret
+kubectl get secret skylab-conn -n crossplane-system -o yaml
+
+# Update kubeconfig (after extracting from secret)
+aws eks update-kubeconfig --region us-east-2 --name skylab
+```
+
+## Scaling
+
+### Node Group Scaling
+The node group can be scaled by updating the Crossplane composition:
+- **Current Size**: 1
+- **Min Size**: 1
+- **Max Size**: 1
+
+## Backup & Recovery
+
+### Cluster State
+- Infrastructure is code-managed via Crossplane
+- Application state should be backed up separately
+- EKS control plane is managed by AWS

--- a/dev/eks/standard/skylab/infra/crossplane/docs/troubleshooting.md
+++ b/dev/eks/standard/skylab/infra/crossplane/docs/troubleshooting.md
@@ -1,0 +1,42 @@
+# Troubleshooting
+
+## Common Issues
+
+### Cluster Not Appearing
+1. Check ArgoCD sync status
+2. Verify ApplicationSet is running
+3. Check cluster labels match ApplicationSet selectors
+
+### Resources Stuck in Provisioning
+1. Check Crossplane provider logs:
+   ```bash
+   kubectl logs -n crossplane-system deployment/crossplane-provider-aws
+   ```
+2. Verify AWS credentials and permissions
+3. Check resource events in AWS console
+
+### Access Denied
+1. Verify IAM roles are properly attached
+2. Check security group rules
+3. Confirm VPC and subnet configuration
+
+## Useful Commands
+
+```bash
+# Check all Crossplane resources for this cluster
+kubectl get managed -A -l cluster-name=skylab
+
+# View Crossplane events
+kubectl get events -n crossplane-system
+
+# Check provider configuration
+kubectl get providerconfigs
+
+# View composition status
+kubectl describe composition skylab-eks-cluster
+```
+
+## Support Contacts
+
+- **Platform Team**: platform-team@skylab.com
+- **On-call**: See PagerDuty rotation

--- a/dev/eks/standard/skylab/infra/crossplane/kustomization.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: skylab-crossplane-cluster
+
+resources:
+  - manifests/xclusterrbac.yaml
+  - manifests/xnetwork.yaml
+  - manifests/xekscluster.yaml
+  - manifests/xeksaccessentries.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: crossplane
+    layer: infra
+    component: crossplane
+
+namespace: crossplane-system
+
+patches:
+  - target:
+      kind: Composition
+      name: skylab-eks-cluster
+    patch: |-
+      - op: add
+        path: /metadata/labels/backstage.io~1managed-by
+        value: template

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xclusterrbac.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xclusterrbac.yaml
@@ -1,0 +1,21 @@
+
+
+---
+apiVersion: infrastructure.skylab.com/v1alpha1
+kind: XClusterRBAC
+metadata:
+  name: skylab-rbac
+  namespace: crossplane-skylab
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: backstage-template
+    template: eks-cluster-crossplane
+    component: rbac
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    template.backstage.io/created-by: skylab-eks-cluster-template
+spec:
+  clusterName: skylab-dev
+  environment: dev

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
@@ -1,0 +1,24 @@
+
+---
+apiVersion: infrastructure.skylab.com/v1alpha1
+kind: XEKSAccessEntries
+metadata:
+  name: skylab-admin-access
+  namespace: crossplane-skylab
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: backstage-template
+    template: eks-cluster-crossplane
+    component: admin-access
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    template.backstage.io/created-by: skylab-eks-cluster-template
+spec:
+  clusterName: skylab-dev
+  region: us-east-2
+  awsAccountId: "635314249418"
+  adminPrincipal:
+    name: chicken
+    type: user

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xekscluster.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xekscluster.yaml
@@ -1,0 +1,41 @@
+
+---
+apiVersion: infrastructure.skylab.com/v1alpha1
+kind: XEKSCluster
+metadata:
+  name: skylab-cluster
+  namespace: crossplane-skylab
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: backstage-template
+    template: eks-cluster-crossplane
+    component: cluster
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    template.backstage.io/created-by: skylab-eks-cluster-template
+spec:
+  clusterName: skylab-dev
+  region: us-east-2
+  environment: dev
+  clusterType: standard
+  kubernetesVersion: "1.33"
+  
+  networkName: skylab-dev
+  rbacName: skylab-dev
+  
+  endpointAccess:
+    private: false
+    public: true
+    publicAccessCidrs: ["0.0.0.0/0"]
+  
+  nodeGroup:
+    desiredSize: 1
+    minSize: 1
+    maxSize: 3
+    instanceTypes: 
+      - t3.medium
+    capacityType: ON_DEMAND
+    amiType: AL2023_x86_64_STANDARD
+    diskSize: 20

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xnetwork.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xnetwork.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: infrastructure.skylab.com/v1alpha1
+kind: XNetwork
+metadata:
+  name: skylab-network
+  namespace: crossplane-skylab
+  labels:
+    environment: dev
+    cluster-type: eks
+    cluster-name: skylab
+    managed-by: backstage-template
+    template: eks-cluster-crossplane
+    component: network
+  annotations:
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    template.backstage.io/created-by: skylab-eks-cluster-template
+spec:
+  networkName: skylab-dev
+  region: us-east-2
+  environment: dev
+  clusterType: standard
+  vpcCidr: "10.10.0.0/16"
+  subnetCidrs:
+    - "10.10.1.0/24"
+    - "10.10.2.0/24"
+  
+  allowedCidrs:
+    - "0.0.0.0/0"

--- a/dev/eks/standard/skylab/infra/crossplane/techdocs.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/techdocs.yaml
@@ -1,0 +1,18 @@
+---
+site_name: 'Skylab EKS Cluster'
+site_description: 'Documentation for skylab EKS cluster infrastructure'
+
+nav:
+  - Overview: index.md
+  - Architecture: architecture.md
+  - Operations: operations.md
+  - Troubleshooting: troubleshooting.md
+
+plugins:
+  - techdocs-core
+
+theme:
+  name: material
+  palette:
+    primary: green
+    accent: black


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1 (min: 1, max: 3)
- **Node Size**: t3.medium
- **Capacity Type**: ON_DEMAND

### Access Configuration
- **Admin Access**: chicken (user) - AmazonEKSClusterAdminPolicy

### Components Created
- **Network composition** (VPC, subnets, security groups, routing)
- **RBAC composition** (IAM roles and policies for EKS)
- **EKS cluster composition** (cluster, node group, add-ons)
- **Admin access composition** (admin access entry + policy association)

This PR adds new modular cluster infrastructure to `dev/eks/standard/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
