### PR TITLE
Add standard EKS cluster: skylab

### DIFF
--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xclusterrbac.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xclusterrbac.yaml
@@ -14,7 +14,7 @@ metadata:
     template: eks-cluster-crossplane
     component: rbac
   annotations:
-    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
     template.backstage.io/created-by: skylab-eks-cluster-template
 spec:
   clusterName: skylab-dev

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xeksaccessentries.yaml
@@ -13,7 +13,7 @@ metadata:
     template: eks-cluster-crossplane
     component: admin-access
   annotations:
-    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
     template.backstage.io/created-by: skylab-eks-cluster-template
 spec:
   clusterName: skylab-dev

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xekscluster.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xekscluster.yaml
@@ -13,7 +13,7 @@ metadata:
     template: eks-cluster-crossplane
     component: cluster
   annotations:
-    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
     template.backstage.io/created-by: skylab-eks-cluster-template
 spec:
   clusterName: skylab-dev

--- a/dev/eks/standard/skylab/infra/crossplane/manifests/xnetwork.yaml
+++ b/dev/eks/standard/skylab/infra/crossplane/manifests/xnetwork.yaml
@@ -12,7 +12,7 @@ metadata:
     template: eks-cluster-crossplane
     component: network
   annotations:
-    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/skylab/infra/crossplane/catalog-info.yaml
+    backstage.io/managed-by-location: url:https://github.com/SkylarHoughtonGithub/skylab-backstage-configs/blob/main/dev/eks/standard/skylab/infra/crossplane/catalog-info.yaml
     template.backstage.io/created-by: skylab-eks-cluster-template
 spec:
   networkName: skylab-dev


### PR DESCRIPTION
## New EKS Cluster Infrastructure

- **Cluster Name**: skylab
- **Environment**: dev
- **Cluster Type**: eks
- **Variant**: standard
- **Region**: us-east-2
- **Node Count**: 1 (min: 1, max: 3)
- **Node Size**: t3.medium
- **Capacity Type**: ON_DEMAND

### Access Configuration
- **Admin Access**: chicken (user) - AmazonEKSClusterAdminPolicy

### Components Created
- **Network composition** (VPC, subnets, security groups, routing)
- **RBAC composition** (IAM roles and policies for EKS)
- **EKS cluster composition** (cluster, node group, add-ons)
- **Admin access composition** (admin access entry + policy association)

This PR adds new modular cluster infrastructure to `dev/eks/standard/skylab/infra/crossplane/`

The cluster will be managed by Crossplane and deployed via ArgoCD ApplicationSet.
